### PR TITLE
[INT-3586] Skip Duplicate Channel Creation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,10 +4,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.ts'],
   coverageThreshold: {
     global: {
-      statements: 50,
-      branches: 0,
+      statements: 95,
+      branches: 95,
       functions: 100,
-      lines: 50,
+      lines: 95,
     },
   },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 95,
-      branches: 95,
+      branches: 75,
       functions: 100,
       lines: 95,
     },

--- a/src/provider/SlackProvider.ts
+++ b/src/provider/SlackProvider.ts
@@ -166,18 +166,9 @@ export class SlackWebClient extends WebClient {
         },
       )) as WebAPICallResult & { channels: any[] };
 
-      // TODO: INT-3586: We are adding this for debugging purposes.
-      // We should have been checking ok regardless, but this will help
-      // catch any upstream errors causing duplicate channels.
-      // When we remove this we should also turn the coverage thresholds
-      // back to 100%
-      // @zemberdotnet
-      if (!listChannelsResponse.ok) {
-        this.integrationLogger.warn('Slack API call not ok', {
-          ok: listChannelsResponse.ok,
-          error: listChannelsResponse.error!,
-        });
-      }
+      // TODO: INT-3586: We should verify that we handle the slack
+      // api response correctly. Slack docs say we should check the `ok`
+      // property evert time, but we haven't. It may be a non-issue.
 
       const numChannelsOnPage = listChannelsResponse.channels.length;
       this.integrationLogger.debug(

--- a/src/steps/fetch-channels/index.ts
+++ b/src/steps/fetch-channels/index.ts
@@ -1,8 +1,4 @@
-import {
-  Entity,
-  getRawData,
-  IntegrationStep,
-} from '@jupiterone/integration-sdk-core';
+import { IntegrationStep } from '@jupiterone/integration-sdk-core';
 import { createSlackClient } from '../../provider';
 import { SlackChannel } from '../../provider/types';
 import {
@@ -28,34 +24,23 @@ const step: IntegrationStep<SlackIntegrationConfig> = {
     const { instance, jobState } = context;
     const client = createSlackClient(context);
     await client.iterateChannels(async (channel: SlackChannel) => {
-      // We have been seeing duplicate channels returned from the API.
-      // TODO: This is here for INT-3586. @zemberdotnet
       const key = toChannelEntityKey({
         teamId: instance.config.teamId,
         channelId: channel.id,
       });
-      // Check if we have already created this channel.
-      // If we have, then we log extra details
-      if (jobState.hasKey(key)) {
-        const existingChannel = (await jobState.findEntity(key)) as Entity;
-        const rawData = getRawData<SlackChannel>(existingChannel);
 
-        context.logger.warn('Duplicate channel found. Diff:', {
-          isChannel: channel.is_channel === rawData.is_channel,
-          isArchived: channel.is_archived === rawData.is_archived,
-          topicLastSet: channel.topic?.last_set === rawData.topic?.last_set,
-          purposeLastSet:
-            channel.purpose?.last_set === rawData.purpose?.last_set,
-          numMembers: channel.num_members === rawData.num_members,
-          prevNamesNum:
-            channel.previous_names?.length === rawData.previous_names?.length,
-          objectDiff: JSON.stringify(channel) === JSON.stringify(rawData),
-        });
+      // We occasionally see duplicate channels, but after
+      // comparing the duplicate channels they matched exactly.
+      // So, if we see the same key again we skip creation.
+      if (!jobState.hasKey(key)) {
+        await jobState.addEntity(
+          createChannelEntity(instance.config.teamId, channel),
+        );
+      } else {
+        context.logger.debug(
+          `Skipping slack_channel entity creation: ${channel.id}`,
+        );
       }
-
-      await jobState.addEntity(
-        createChannelEntity(instance.config.teamId, channel),
-      );
     });
   },
 };

--- a/src/steps/fetch-channels/index.ts
+++ b/src/steps/fetch-channels/index.ts
@@ -38,7 +38,10 @@ const step: IntegrationStep<SlackIntegrationConfig> = {
         );
       } else {
         context.logger.debug(
-          `Skipping slack_channel entity creation: ${channel.id}`,
+          {
+            channelId: channel.id,
+          },
+          'Skipping slack_channel creation',
         );
       }
     });


### PR DESCRIPTION
# Description

This PR adds logic to skip the creation of a `slack_channel` of one with the same `_key` already exists. This is after comparing the duplicate objects for similarity and finding they were the exact same.

We may misunderstand something about Slack API pagination, but this is a low risk fix for the moment.