### PR TITLE
Add teamId to channel entity

### DIFF
--- a/src/converters.ts
+++ b/src/converters.ts
@@ -143,6 +143,7 @@ export function createChannelEntity(
         purposeCreator: channel.purpose.creator,
         purposeLastSet: channel.purpose.last_set,
         numMembers: channel.num_members,
+        teamId: teamId,
       },
     },
   });


### PR DESCRIPTION
# Description

This PR adds the `teamId` property to the channel entity. This will enable creating mapped relationships based on webhook urls.

For a specific example, consider this response from the DigitalOcean API:
```json
"slack": [
    {
        "channel": "Production Alerts",
        "url": "https://hooks.slack.com/services/T1234567/AAAAAAAA/ZZZZZZ%22"
    }
]
```

This response features the channel name (which is a unique identifier for a channel within a team), and the teamId in the url `T1234567`. Currently, a mapped relationship couldn't be made because an account may have multiple teams which would make the channel name insufficiently unique. If the `teamId` property is present on the channel, then a mapped relationships could be made using the combination of `teamId` and `name` to uniquely identify the channel to map to.

