### PR TITLE
Release 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 4.2.0 - 2022
+
+### Added
+
+- added `teamId` property to `channel` entities
 
 ## 4.1.0 - 2022-07-01
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-slack",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "A graph conversion tool for https://slack.com",
   "license": "MPL-2.0",
   "main": "src/index.js",


### PR DESCRIPTION
# Description

Release 4.2.0 adds the `teamId` property to `channel` entities.